### PR TITLE
Don't use ext-readline handler on Mac to fix CR/LF issues on Mac only

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,11 +607,11 @@ If this extension is missing, then this library will use a slighty slower Regex
 work-around that should otherwise work equally well.
 Installing `ext-mbstring` is highly recommended.
 
-Internally, it will use the `ext-readline` to enable raw terminal input mode.
-If this extension is missing, then this library will manually set the required
-TTY settings on start and will try to restore previous settings on exit.
-Input line editing is handled entirely within this library and does not rely on
-`ext-readline`.
+Internally, it will use the `ext-readline` to enable raw terminal input mode (on
+Linux only as it is known to cause issues on Macs). Otherwise, this library will
+manually set the required TTY settings on start and will try to restore previous
+settings on exit. Input line editing is handled entirely within this library and
+does not rely on `ext-readline`.
 Installing `ext-readline` is entirely optional.
 
 Note that *Microsoft Windows is not supported*.

--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -2,8 +2,6 @@
 
 namespace Clue\React\Stdio;
 
-use Clue\React\Stdio\Io\Stdin;
-use Clue\React\Stdio\Io\Stdout;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Stream\DuplexStreamInterface;
@@ -23,6 +21,7 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
     private $closed = false;
     private $incompleteLine = '';
     private $originalTtyMode = null;
+    private $usesExtReadlineHandler = false;
 
     public function __construct(LoopInterface $loop, ReadableStreamInterface $input = null, WritableStreamInterface $output = null, Readline $readline = null)
     {
@@ -246,8 +245,9 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
      */
     private function restoreTtyMode()
     {
-        if (function_exists('readline_callback_handler_remove')) {
+        if ($this->usesExtReadlineHandler) {
             // remove dummy readline handler to turn to default input mode
+            $this->usesExtReadlineHandler = false;
             readline_callback_handler_remove();
         } elseif ($this->originalTtyMode !== null && $this->isTty()) {
             // Reset stty so it behaves normally again
@@ -279,11 +279,14 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
 
         $stream = new ReadableResourceStream(STDIN, $loop);
 
-        if (function_exists('readline_callback_handler_install')) {
+        if (PHP_OS === 'Linux' && function_exists('readline_callback_handler_install')) {
             // Prefer `ext-readline` to install dummy handler to turn on raw input mode.
+            // This is known to work on Linux and known to cause issues with CR/LF
+            // on Mac, so we only use this on Linux for now, see also issue #66.
             // We will nevery actually feed the readline handler and instead
             // handle all input in our `Readline` implementation.
             readline_callback_handler_install('', function () { });
+            $this->usesExtReadlineHandler = true;
             return $stream;
         }
 


### PR DESCRIPTION
Resolves / closes #66 