### PR TITLE
Enhancement: Keep packages sorted in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,11 @@
         "psr-4": { "Clue\\React\\Stdio\\": "src/" }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35",
+        "clue/arguments": "^2.0",
         "clue/commander": "^1.2",
-        "clue/arguments": "^2.0"
+        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages. 

I ran

```
$ composer config sort-packages true
```

followed by

```
$ composer require --dev clue/commander:^1.2
```

to trigger sorting the `require-dev` section (note that `require` is already sorted).