### PR TITLE
Fix restoring TTY mode when ext-readline is not in use

### DIFF
--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -291,7 +291,7 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
         }
 
         if ($this->isTty()) {
-            $this->originalTtyMode = shell_exec('stty -g');
+            $this->originalTtyMode = rtrim(shell_exec('stty -g'), PHP_EOL);
 
             // Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
             shell_exec('stty -icanon -echo');

--- a/tests/FunctionalExampleTest.php
+++ b/tests/FunctionalExampleTest.php
@@ -87,6 +87,20 @@ class FunctionalExampleTest extends TestCase
         $this->assertEquals('', $output);
     }
 
+    public function testStubCanEndWithoutOutput()
+    {
+        $output = $this->execExample('php ../tests/stub/04-end.php');
+
+        $this->assertEquals('', $output);
+    }
+
+    public function testStubCanEndWithoutExtensions()
+    {
+        $output = $this->execExample('php -n ../tests/stub/04-end.php');
+
+        $this->assertEquals('', $output);
+    }
+
     public function testPeriodicExampleViaInteractiveModeQuitsImmediately()
     {
         if (defined('HHVM_VERSION')) {

--- a/tests/stub/04-end.php
+++ b/tests/stub/04-end.php
@@ -1,0 +1,12 @@
+<?php
+
+use Clue\React\Stdio\Stdio;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+
+$stdio = new Stdio($loop);
+$stdio->end();
+
+$loop->run();


### PR DESCRIPTION
This fixes a bug that was recently introduced via #74 that did not remove the trailing newline character when trying to restore TTY mode when ext-readline is not in use.