### PR TITLE
Accept CR as an alias for LF to support more platforms

### DIFF
--- a/src/Readline.php
+++ b/src/Readline.php
@@ -44,10 +44,16 @@ class Readline extends EventEmitter implements ReadableStreamInterface
 
         $that = $this;
         $codes = array(
-            "\n" => 'onKeyEnter',
-            "\x7f" => 'onKeyBackspace',
-            "\t" => 'onKeyTab',
+            // The user confirms input with enter key which should usually
+            // generate a NL (`\n`) character. Common terminals also seem to
+            // accept a CR (`\r`) character in place and handle this just like a
+            // NL. Similarly `ext-readline` uses different `icrnl` and `igncr`
+            // TTY settings on some platforms, so we also accept both here.
+            "\n" => 'onKeyEnter', // ^J
+            "\r" => 'onKeyEnter', // ^M
 
+            "\x7f" => 'onKeyBackspace',
+            "\t"   => 'onKeyTab',
             "\x04" => 'handleEnd', // CTRL+D
 
             "\033[A" => 'onKeyUp',

--- a/src/Readline.php
+++ b/src/Readline.php
@@ -44,17 +44,10 @@ class Readline extends EventEmitter implements ReadableStreamInterface
 
         $that = $this;
         $codes = array(
-            // The user confirms input with enter key which should usually
-            // generate a NL (`\n`) character. Common terminals also seem to
-            // accept a CR (`\r`) character in place and handle this just like a
-            // NL. Similarly `ext-readline` uses different `icrnl` and `igncr`
-            // TTY settings on some platforms, so we also accept both here.
-            "\n" => 'onKeyEnter', // ^J
-            "\r" => 'onKeyEnter', // ^M
-
-            "\x7f" => 'onKeyBackspace',
-            "\t"   => 'onKeyTab',
-            "\x04" => 'handleEnd', // CTRL+D
+            "\n"   => 'onKeyEnter', // ^J
+            "\x7f" => 'onKeyBackspace', // ^?
+            "\t"   => 'onKeyTab', // ^I
+            "\x04" => 'handleEnd', // ^D
 
             "\033[A" => 'onKeyUp',
             "\033[B" => 'onKeyDown',
@@ -69,6 +62,16 @@ class Readline extends EventEmitter implements ReadableStreamInterface
 //          "\033[20~" => 'onKeyF10',
         );
         $decode = function ($code) use ($codes, $that) {
+            // The user confirms input with enter key which should usually
+            // generate a NL (`\n`) character. Common terminals also seem to
+            // accept a CR (`\r`) character in place and handle this just like a
+            // NL. Similarly `ext-readline` uses different `icrnl` and `igncr`
+            // TTY settings on some platforms, so we also accept CR as an alias
+            // for NL here. This implies key binding for NL will also trigger.
+            if ($code === "\r") {
+                $code = "\n";
+            }
+
             if ($that->listeners($code)) {
                 $that->emit($code, array($code));
                 return;

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -228,11 +228,18 @@ class ReadlineTest extends TestCase
         $this->assertSame($this->readline, $this->readline->moveCursorBy(2));
     }
 
-    public function testDataEventWillBeEmittedForCompleteLine()
+    public function testDataEventWillBeEmittedForCompleteLineWithNl()
     {
         $this->readline->on('data', $this->expectCallableOnceWith("hello\n"));
 
         $this->input->emit('data', array("hello\n"));
+    }
+
+    public function testDataEventWillBeEmittedWithNlAlsoForCompleteLineWithCr()
+    {
+        $this->readline->on('data', $this->expectCallableOnceWith("hello\n"));
+
+        $this->input->emit('data', array("hello\r"));
     }
 
     public function testDataEventWillNotBeEmittedForIncompleteLineButWillStayInInputBuffer()

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -988,6 +988,23 @@ class ReadlineTest extends TestCase
         $this->input->emit('data', array("\t"));
     }
 
+    public function testBindCustomFunctionToNlOverwritesDataEvent()
+    {
+        $this->readline->on("\n", $this->expectCallableOnceWith("\n"));
+        $this->readline->on('line', $this->expectCallableNever());
+
+        $this->input->emit('data', array("hello\n"));
+    }
+
+    public function testBindCustomFunctionToNlFiresOnCr()
+    {
+        $this->readline->on("\n", $this->expectCallableOnceWith("\n"));
+        $this->readline->on("\r", $this->expectCallableNever());
+        $this->readline->on('line', $this->expectCallableNever());
+
+        $this->input->emit('data', array("hello\r"));
+    }
+
     public function testEmitEmptyInputOnEnter()
     {
         $this->readline->on('data', $this->expectCallableOnceWith("\n"));


### PR DESCRIPTION
The <kbd>enter</kbd> key will usually end the line with a `\n` (LF) character on most Unix platforms. Common terminals also accept the <kbd>^M</kbd> (CR) key in place of the <kbd>^J</kbd> (LF) key.

By now allowing CR as an alias for LF in this library, we can significantly improve compatibility with this common usage pattern and improve platform support. In particular, some platforms use different TTY settings (`icrnl`, `igncr` and family) and depending on these settings emit different EOL characters. This fixes issues where <kbd>enter</kbd> was not properly detected when using `ext-readline` on Mac OS X, Android and others.

Note that Windows technically uses `\r\n` (CRLF), but this platform is not supported at the moment anyway (#18). I've actually implemented logic to ensure CRLF is only handled as a single line, but reverted this for the PR because this does not seem to be implemented in common terminals either (`echo -en "\r\n" | bash -i` shows two independent lines and both <kbd>^J</kbd> and <kbd>^M</kbd> show a `\n` in `hd`).

Resolves / closes #66 
Resolves / closes #77 
Supersedes #73 