### PR TITLE
Revert "Don't use ext-readline handler on Mac to fix CR/LF issues on Mac only

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,11 +607,11 @@ If this extension is missing, then this library will use a slighty slower Regex
 work-around that should otherwise work equally well.
 Installing `ext-mbstring` is highly recommended.
 
-Internally, it will use the `ext-readline` to enable raw terminal input mode (on
-Linux only as it is known to cause issues on Macs). Otherwise, this library will
-manually set the required TTY settings on start and will try to restore previous
-settings on exit. Input line editing is handled entirely within this library and
-does not rely on `ext-readline`.
+Internally, it will use the `ext-readline` to enable raw terminal input mode.
+If this extension is missing, then this library will manually set the required
+TTY settings on start and will try to restore previous settings on exit.
+Input line editing is handled entirely within this library and does not rely on
+`ext-readline`.
 Installing `ext-readline` is entirely optional.
 
 Note that *Microsoft Windows is not supported*.


### PR DESCRIPTION
This reverts #73 now that #79 addresses the underlying issues. This means that `ext-readline` will now be used again on all platforms that support it, including Mac OS X.