### PR TITLE
Deprecate Readline and move all methods to Stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ without requiring any extensions or special installation.
   * [Stdio](#stdio)
     * [Output](#output)
     * [Input](#input)
-  * [Readline](#readline)
     * [Prompt](#prompt)
     * [Echo](#echo)
     * [Input buffer](#input-buffer)
@@ -25,6 +24,7 @@ without requiring any extensions or special installation.
     * [History](#history)
     * [Autocomplete](#autocomplete)
     * [Keys](#keys)
+  * [Readline](#readline)
 * [Pitfalls](#pitfalls)
 * [Install](#install)
 * [Tests](#tests)
@@ -39,7 +39,7 @@ Once [installed](#install), you can use the following code to present a prompt i
 $loop = React\EventLoop\Factory::create();
 $stdio = new Stdio($loop);
 
-$stdio->getReadline()->setPrompt('Input > ');
+$stdio->setPrompt('Input > ');
 
 $stdio->on('data', function ($line) use ($stdio) {
     $line = rtrim($line, "\r\n");
@@ -135,33 +135,12 @@ Because the `Stdio` is a well-behaving readable stream that will emit incoming
 data as-is, you can also use this to `pipe()` this stream into other writable
 streams.
 
-```
+```php
 $stdio->pipe($logger);
 ```
 
-You can control various aspects of the console input through the [`Readline`](#readline),
+You can control various aspects of the console input through this interface,
 so read on..
-
-### Readline
-
-The [`Readline`](#readline) class is responsible for reacting to user input and presenting a prompt to the user.
-It does so by reading individual bytes from the input stream and writing the current *user input line* to the output stream.
-
-The *user input line* consists of a *prompt*, following by the current *user input buffer*.
-The `Readline` allows you to control various aspects of this *user input line*.
-
-You can access the current instance through the [`Stdio`](#stdio):
-
-```php
-$readline = $stdio->getReadline();
-```
-
-See above for waiting for user input.
-
-Alternatively, the `Readline` is also a well-behaving readable stream
-(implementing ReactPHP's `ReadableStreamInterface`) that emits each complete
-line as a `data` event, including the trailing newline.
-This is considered advanced usage.
 
 #### Prompt
 
@@ -171,21 +150,21 @@ The `setPrompt($prompt)` method can be used to change the input prompt.
 The prompt will be printed to the *user input line* as-is, so you will likely want to end this with a space:
 
 ```php
-$readline->setPrompt('Input: ');
+$stdio->setPrompt('Input: ');
 ```
 
 The default input prompt is empty, i.e. the *user input line* contains only the actual *user input buffer*.
 You can restore this behavior by passing an empty prompt:
 
 ```php
-$readline->setPrompt('');
+$stdio->setPrompt('');
 ```
 
 The `getPrompt()` method can be used to get the current input prompt.
 It will return an empty string unless you've set anything else:
 
 ```php
-assert($readline->getPrompt() === '');
+assert($stdio->getPrompt() === '');
 ```
 
 #### Echo
@@ -201,7 +180,7 @@ Please note that this often leads to a bad user experience as users will not eve
 Simply pass a boolean `false` like this:
 
 ```php
-$readline->setEcho(false);
+$stdio->setEcho(false);
 ```
 
 Alternatively, you can also *hide* the *user input buffer* by using a replacement character.
@@ -211,13 +190,13 @@ This often provides a better user experience and allows users to still control t
 Simply pass a string replacement character likes this:
 
 ```php
-$readline->setEcho('*');
+$stdio->setEcho('*');
 ```
 
 To restore the original behavior where every character appears as-is, simply pass a boolean `true`:
 
 ```php
-$readline->setEcho(true);
+$stdio->setEcho(true);
 ```
 
 #### Input buffer
@@ -235,7 +214,7 @@ the user (like the last password attempt).
 Simply pass an input string like this:
 
 ```php
-$readline->addInput('hello');
+$stdio->addInput('hello');
 ```
 
 The `setInput($buffer)` method can be used to control the *user input buffer*.
@@ -247,7 +226,7 @@ the user (like the last password attempt).
 Simply pass an input string like this:
 
 ```php
-$readline->setInput('lastpass');
+$stdio->setInput('lastpass');
 ```
 
 The `getInput()` method can be used to access the current *user input buffer*.
@@ -255,7 +234,7 @@ This can be useful if you want to append some input behind the current *user inp
 You can simply access the buffer like this:
 
 ```php
-$buffer = $readline->getInput();
+$buffer = $stdio->getInput();
 ```
 
 #### Cursor
@@ -267,14 +246,14 @@ The `setMove($toggle)` method can be used to control whether users are allowed t
 To disable the left and right arrow keys, simply pass a boolean `false` like this:
 
 ```php
-$readline->setMove(false);
+$stdio->setMove(false);
 ```
 
 To restore the default behavior where the user can use the left and right arrow keys,
 simply pass a boolean `true` like this:
 
 ```php
-$readline->setMove(true);
+$stdio->setMove(true);
 ```
 
 The `getCursorPosition()` method can be used to access the current cursor position,
@@ -283,7 +262,7 @@ This can be useful if you want to get a substring of the current *user input buf
 Simply invoke it like this:
 
 ```php
-$position = $readline->getCursorPosition();
+$position = $stdio->getCursorPosition();
 ```
 
 The `getCursorCell()` method can be used to get the current cursor position,
@@ -296,14 +275,14 @@ This method is mostly useful for calculating the visual cursor position on scree
 but you may also invoke it like this:
 
 ```php
-$cell = $readline->getCursorCell();
+$cell = $stdio->getCursorCell();
 ```
 
 The `moveCursorTo($position)` method can be used to set the current cursor position to the given absolute character position.
 For example, to move the cursor to the beginning of the *user input buffer*, simply call:
 
 ```php
-$readline->moveCursorTo(0);
+$stdio->moveCursorTo(0);
 ```
 
 The `moveCursorBy($offset)` method can be used to change the cursor position
@@ -312,7 +291,7 @@ A positive number will move the cursor to the right - a negative number will mov
 For example, to move the cursor one character to the left, simply call:
 
 ```php
-$readline->moveCursorBy(-1);
+$stdio->moveCursorBy(-1);
 ```
 
 #### History
@@ -331,13 +310,13 @@ If you want to automatically add everything from the user input to the history,
 you may want to use something like this:
 
 ```php
-$stdio->on('data', function ($line) use ($readline) {
+$stdio->on('data', function ($line) use ($stdio) {
     $line = rtrim($line);
-    $all = $readline->listHistory();
+    $all = $stdio->listHistory();
 
     // skip empty line and duplicate of previous line
     if ($line !== '' && $line !== end($all)) {
-        $readline->addHistory($line);
+        $stdio->addHistory($line);
     }
 });
 ```
@@ -347,24 +326,24 @@ return an array with all lines in the history.
 This will be an empty array until you add new entries via `addHistory()`.
 
 ```php
-$list = $readline->listHistory();
+$list = $stdio->listHistory();
 
 assert(count($list) === 0);
 ```
 
-The `addHistory(string $line): Readline` method can be used to
+The `addHistory(string $line): void` method can be used to
 add a new line to the (bottom position of the) history list.
 A following `listHistory()` call will return this line as the last element.
 
 ```php
-$readline->addHistory('a');
-$readline->addHistory('b');
+$stdio->addHistory('a');
+$stdio->addHistory('b');
 
-$list = $readline->listHistory();
+$list = $stdio->listHistory();
 assert($list === array('a', 'b'));
 ```
 
-The `clearHistory(): Readline` method can be used to
+The `clearHistory(): void` method can be used to
 clear the complete history list.
 A following `listHistory()` call will return an empty array until you add new
 entries via `addHistory()` again.
@@ -372,13 +351,13 @@ Note that the history feature will effectively be disabled if the history is
 empty, as the UP and DOWN cursor keys have no function then.
 
 ```php
-$readline->clearHistory();
+$stdio->clearHistory();
 
-$list = $readline->listHistory();
+$list = $stdio->listHistory();
 assert(count($list) === 0);
 ```
 
-The `limitHistory(?int $limit): Readline` method can be used to
+The `limitHistory(?int $limit): void` method can be used to
 set a limit of history lines to keep in memory.
 By default, only the last 500 lines will be kept in memory and everything else
 will be discarded.
@@ -394,10 +373,10 @@ this to obey the `HISTSIZE` environment variable:
 $limit = getenv('HISTSIZE');
 if ($limit === '' || $limit < 0) {
     // empty string or negative value means unlimited
-    $readline->limitHistory(null);
+    $stdio->limitHistory(null);
 } elseif ($limit !== false) {
     // apply any other value if given
-    $readline->limitHistory($limit);
+    $stdio->limitHistory($limit);
 }
 ```
 
@@ -415,13 +394,13 @@ By default, users can use autocompletion by using their TAB keys on the keyboard
 The autocomplete function is not registered by default, thus this feature is
 effectively disabled, as the TAB key has no function then.
 
-The `setAutocomplete(?callable $autocomplete): Readline` method can be used to
+The `setAutocomplete(?callable $autocomplete): void` method can be used to
 register a new autocomplete handler.
 In its most simple form, you won't need to assign any arguments and can simply
 return an array of possible word matches from a callable like this:
 
 ```php
-$readline->setAutocomplete(function () {
+$stdio->setAutocomplete(function () {
     return array(
         'exit',
         'echo',
@@ -464,7 +443,7 @@ is an argument or a root command and the `$word` argument to autocomplete
 partial filename matches like this:
 
 ```php
-$readline->setAutocomplete(function ($word, $offset) {
+$stdio->setAutocomplete(function ($word, $offset) {
     if ($offset <= 1) {
         // autocomplete root commands at offset=0/1 only
         return array('cat', 'rm', 'stat');
@@ -486,10 +465,10 @@ and/or manipulate the [input buffer](#input-buffer) and [cursor](#cursor)
 directly like this:
 
 ```php
-$readline->setAutocomplete(function () use ($readline) {
-    if ($readline->getInput() === 'run') {
-        $readline->setInput('run --test --value=42');
-        $readline->moveCursorBy(-2);
+$stdio->setAutocomplete(function () use ($stdio) {
+    if ($stdio->getInput() === 'run') {
+        $stdio->setInput('run --test --value=42');
+        $stdio->moveCursorBy(-2);
     }
 
     // return empty array so normal autocompletion doesn't kick in
@@ -501,7 +480,7 @@ You can use a `null` value to remove the autocomplete function again and thus
 disable the autocomplete function:
 
 ```php
-$readline->setAutocomplete(null);
+$stdio->setAutocomplete(null);
 ```
 
 #### Keys
@@ -527,7 +506,7 @@ For example, you can use the following code to print some help text when the
 user hits a certain key:
 
 ```php
-$readline->on('?', function () use ($stdio) {
+$stdio->on('?', function () use ($stdio) {
      $stdio->write('Here\'s some help: …' . PHP_EOL);
 });
 ```
@@ -536,8 +515,8 @@ Similarly, this can be used to manipulate the user input and replace some of the
 input when the user hits a certain key:
 
 ```php
-$readline->on('ä', function () use ($readline) {
-     $readline->addInput('a');
+$stdio->on('ä', function () use ($stdio) {
+     $stdio->addInput('a');
 });
 ```
 
@@ -550,14 +529,47 @@ For example, the following code can be used to register a custom function to the
 UP arrow cursor key:
 
 ```php
-$readline->on("\033[A", function () use ($readline) {
-     $readline->setInput(strtoupper($readline->getInput()));
+$stdio->on("\033[A", function () use ($stdio) {
+     $stdio->setInput(strtoupper($stdio->getInput()));
 });
 ```
 
+### Readline
+
+The deprecated `Readline` class is responsible for reacting to user input and
+presenting a prompt to the user. It does so by reading individual bytes from the
+input stream and writing the current *user input line* to the output stream.
+
+The deprecated `Readline` class is only used internally and should no longer be
+referenced from consuming projects.
+
+You can access the current instance through the [`Stdio`](#stdio):
+
+```php
+// deprecated
+$readline = $stdio->getReadline();
+```
+
+All methods that are available on the `Readline` instance are now available on
+the `Stdio` class. For BC reasons, they remain available on the `Readline` class
+until the next major release, see also above for more details.
+
+```php
+// deprecated
+$readline->setPrompt('> ');
+
+// new
+$stdio->setPrompt('> ');
+```
+
+Internally, the `Readline` is also a well-behaving readable stream
+(implementing ReactPHP's `ReadableStreamInterface`) that emits each complete
+line as a `data` event, including the trailing newline.
+This is considered advanced usage.
+
 ## Pitfalls
 
-The [`Readline`](#readline) has to redraw the current user
+The [`Stdio`](#stdio) has to redraw the current user
 input line whenever output is written to the `STDOUT`.
 Because of this, it is important to make sure any output is always
 written like this instead of using `echo` statements:

--- a/examples/02-interactive.php
+++ b/examples/02-interactive.php
@@ -7,36 +7,35 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $stdio = new Stdio($loop);
-$readline = $stdio->getReadline();
 
-$readline->setPrompt('> ');
+$stdio->setPrompt('> ');
 
 // limit history to HISTSIZE env
 $limit = getenv('HISTSIZE');
 if ($limit === '' || $limit < 0) {
     // empty string or negative value means unlimited
-    $readline->limitHistory(null);
+    $stdio->limitHistory(null);
 } elseif ($limit !== false) {
     // apply any other value if given
-    $readline->limitHistory($limit);
+    $stdio->limitHistory($limit);
 }
 
 // autocomplete the following commands (at offset=0/1 only)
-$readline->setAutocomplete(function ($_, $offset) {
+$stdio->setAutocomplete(function ($_, $offset) {
     return $offset > 1 ? array() : array('exit', 'quit', 'help', 'echo', 'print', 'printf');
 });
 
 $stdio->write('Welcome to this interactive demo' . PHP_EOL);
 
 // react to commands the user entered
-$stdio->on('data', function ($line) use ($stdio, $readline) {
+$stdio->on('data', function ($line) use ($stdio) {
     $line = rtrim($line, "\r\n");
 
     // add all lines from input to history
     // skip empty line and duplicate of previous line
-    $all = $readline->listHistory();
+    $all = $stdio->listHistory();
     if ($line !== '' && $line !== end($all)) {
-        $readline->addHistory($line);
+        $stdio->addHistory($line);
     }
 
     $stdio->write('you just said: ' . $line . ' (' . strlen($line) . ')' . PHP_EOL);

--- a/examples/03-commander.php
+++ b/examples/03-commander.php
@@ -10,17 +10,16 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $stdio = new Stdio($loop);
-$readline = $stdio->getReadline();
-$readline->setPrompt('> ');
+$stdio->setPrompt('> ');
 
 // limit history to HISTSIZE env
 $limit = getenv('HISTSIZE');
 if ($limit === '' || $limit < 0) {
     // empty string or negative value means unlimited
-    $readline->limitHistory(null);
+    $stdio->limitHistory(null);
 } elseif ($limit !== false) {
     // apply any other value if given
-    $readline->limitHistory($limit);
+    $stdio->limitHistory($limit);
 }
 
 // register all available commands and their arguments
@@ -39,21 +38,21 @@ $router->add('printf <format> <args>...', function (array $args) use ($stdio) {
 });
 
 // autocomplete the following commands (at offset=0/1 only)
-$readline->setAutocomplete(function ($_, $offset) {
+$stdio->setAutocomplete(function ($_, $offset) {
     return $offset > 1 ? array() : array('exit', 'quit', 'help', 'echo', 'print', 'printf');
 });
 
 $stdio->write('Welcome to this interactive demo' . PHP_EOL);
 
 // react to commands the user entered
-$stdio->on('data', function ($line) use ($router, $stdio, $readline) {
+$stdio->on('data', function ($line) use ($router, $stdio) {
     $line = rtrim($line, "\r\n");
 
     // add all lines from input to history
     // skip empty line and duplicate of previous line
-    $all = $readline->listHistory();
+    $all = $stdio->listHistory();
     if ($line !== '' && $line !== end($all)) {
-        $readline->addHistory($line);
+        $stdio->addHistory($line);
     }
 
     try {

--- a/examples/04-bindings.php
+++ b/examples/04-bindings.php
@@ -7,38 +7,36 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $stdio = new Stdio($loop);
-$readline = $stdio->getReadline();
-
-$readline->setPrompt('> ');
+$stdio->setPrompt('> ');
 
 // add some special key bindings
-$readline->on('a', function () use ($readline) {
-    $readline->addInput('ä');
+$stdio->on('a', function () use ($stdio) {
+    $stdio->addInput('ä');
 });
-$readline->on('o', function () use ($readline) {
-    $readline->addInput('ö');
+$stdio->on('o', function () use ($stdio) {
+    $stdio->addInput('ö');
 });
-$readline->on('u', function () use ($readline) {
-    $readline->addInput('ü');
+$stdio->on('u', function () use ($stdio) {
+    $stdio->addInput('ü');
 });
 
-$readline->on('?', function () use ($stdio) {
+$stdio->on('?', function () use ($stdio) {
     $stdio->write('Do you need help?');
 });
 
 // bind CTRL+E
-$readline->on("\x05", function () use ($stdio) {
+$stdio->on("\x05", function () use ($stdio) {
     $stdio->write("ignore CTRL+E" . PHP_EOL);
 });
 // bind CTRL+H
-$readline->on("\x08", function () use ($stdio) {
+$stdio->on("\x08", function () use ($stdio) {
     $stdio->write('Use "?" if you need help.' . PHP_EOL);
 });
 
 $stdio->write('Welcome to this interactive demo' . PHP_EOL);
 
 // end once the user enters a command
-$stdio->on('data', function ($line) use ($stdio, $readline) {
+$stdio->on('data', function ($line) use ($stdio) {
     $line = rtrim($line, "\r\n");
     $stdio->end('you just said: ' . $line . ' (' . strlen($line) . ')' . PHP_EOL);
 });

--- a/examples/05-cursor.php
+++ b/examples/05-cursor.php
@@ -7,33 +7,32 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $stdio = new Stdio($loop);
-$readline = $stdio->getReadline();
 
 $value = 10;
-$readline->on("\033[A", function () use (&$value, $readline) {
+$stdio->on("\033[A", function () use (&$value, $stdio) {
     $value++;
-    $readline->setPrompt('Value: ' . $value);
+    $stdio->setPrompt('Value: ' . $value);
 });
-$readline->on("\033[B", function () use (&$value, $readline) {
+$stdio->on("\033[B", function () use (&$value, $stdio) {
     --$value;
-    $readline->setPrompt('Value: ' . $value);
+    $stdio->setPrompt('Value: ' . $value);
 });
 
 // hijack enter to just print our current value
-$readline->on("\n", function () use ($readline, $stdio, &$value) {
+$stdio->on("\n", function () use ($stdio, &$value) {
     $stdio->write("Your choice was $value\n");
 });
 
 // quit on "q"
-$readline->on('q', function () use ($stdio) {
+$stdio->on('q', function () use ($stdio) {
     $stdio->end();
 });
 
 // user can still type all keys, but we simply hide user input
-$readline->setEcho(false);
+$stdio->setEcho(false);
 
 // instead of showing user input, we just show a custom prompt
-$readline->setPrompt('Value: ' . $value);
+$stdio->setPrompt('Value: ' . $value);
 
 $stdio->write('Welcome to this cursor demo
 

--- a/examples/11-login.php
+++ b/examples/11-login.php
@@ -7,8 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $stdio = new Stdio($loop);
-
-$stdio->getReadline()->setPrompt('Username: ');
+$stdio->setPrompt('Username: ');
 
 $first = true;
 $username = null;
@@ -17,8 +16,8 @@ $password = null;
 $stdio->on('data', function ($line) use ($stdio, &$first, &$username, &$password) {
     $line = rtrim($line, "\r\n");
     if ($first) {
-        $stdio->getReadline()->setPrompt('Password: ');
-        $stdio->getReadline()->setEcho('*');
+        $stdio->setPrompt('Password: ');
+        $stdio->setEcho('*');
         $username = $line;
         $first = false;
     } else {

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -2,6 +2,7 @@
 
 use Clue\React\Stdio\Readline;
 use React\Stream\ThroughStream;
+use Evenement\EventEmitter;
 
 class ReadlineTest extends TestCase
 {
@@ -950,6 +951,15 @@ class ReadlineTest extends TestCase
         $this->assertContains("\na  b  c  d  e  f  g  (+19 others)\n", $buffer);
     }
 
+    public function testBindCustomFunctionFromBase()
+    {
+        $base = new EventEmitter();
+        $base->on('a', $this->expectCallableOnceWith('a'));
+
+        $this->readline = new Readline($this->input, $this->output, $base);
+        $this->input->emit('data', array('a'));
+    }
+
     public function testBindCustomFunctionOverwritesInput()
     {
         $this->readline->on('a', $this->expectCallableOnceWith('a'));
@@ -1003,6 +1013,17 @@ class ReadlineTest extends TestCase
         $this->readline->on('line', $this->expectCallableNever());
 
         $this->input->emit('data', array("hello\r"));
+    }
+
+    public function testBindCustomFunctionFromBaseCanOverwriteAutocompleteBehavior()
+    {
+        $base = new EventEmitter();
+        $base->on("\t", $this->expectCallableOnceWith("\t"));
+
+        $this->readline = new Readline($this->input, $this->output, $base);
+        $this->readline->setAutocomplete($this->expectCallableNever());
+
+        $this->input->emit('data', array("\t"));
     }
 
     public function testEmitEmptyInputOnEnter()


### PR DESCRIPTION
Move all public methods to `Stdio` as is, so the recommend way to call these methods now looks like this:

```php
// old
$stdio->getReadline()->setPrompt('> ');

// new
$stdio->setPrompt('> ');
```

The original methods continue to exist and work unchanged until the next major release, at which point the `Readline` class will potentially be removed.