### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -19,10 +19,9 @@ matrix:
   allow_failures:
     - php: hhvm-3.18
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "clue/arguments": "^2.0",
         "clue/commander": "^1.2",
-        "phpunit/phpunit": "^9.3 || ^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "clue/arguments": "^2.0",
         "clue/commander": "^1.2",
-        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^6.4 || ^5.7 || ^4.8.35"
     },
     "config": {
         "sort-packages": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Stdio React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Stdio React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FunctionalExampleTest.php
+++ b/tests/FunctionalExampleTest.php
@@ -8,28 +8,28 @@ class FunctionalExampleTest extends TestCase
     {
         $output = $this->execExample('echo hello | php 01-periodic.php');
 
-        $this->assertContains('you just said: hello\n', $output);
+        $this->assertContainsString('you just said: hello\n', $output);
     }
 
     public function testPeriodicExampleWithNullInputQuitsImmediately()
     {
         $output = $this->execExample('php 01-periodic.php < /dev/null');
 
-        $this->assertNotContains('you just said:', $output);
+        $this->assertNotContainsString('you just said:', $output);
     }
 
     public function testPeriodicExampleWithNoInputQuitsImmediately()
     {
         $output = $this->execExample('true | php 01-periodic.php');
 
-        $this->assertNotContains('you just said:', $output);
+        $this->assertNotContainsString('you just said:', $output);
     }
 
     public function testPeriodicExampleWithSleepNoInputQuitsOnEnd()
     {
         $output = $this->execExample('sleep 0.1 | php 01-periodic.php');
 
-        $this->assertNotContains('you just said:', $output);
+        $this->assertNotContainsString('you just said:', $output);
     }
 
     public function testPeriodicExampleWithClosedInputQuitsImmediately()
@@ -40,7 +40,7 @@ class FunctionalExampleTest extends TestCase
             $this->markTestIncomplete('Your platform exhibits a closed STDIN bug, this may need some further debugging');
         }
 
-        $this->assertNotContains('you just said:', $output);
+        $this->assertNotContainsString('you just said:', $output);
     }
 
     public function testPeriodicExampleWithClosedInputAndOutputQuitsImmediatelyWithoutOutput()
@@ -58,28 +58,28 @@ class FunctionalExampleTest extends TestCase
     {
         $output = $this->execExample('echo test | php 04-bindings.php');
 
-        $this->assertContains('you just said: test (4)' . PHP_EOL, $output);
+        $this->assertContainsString('you just said: test (4)' . PHP_EOL, $output);
     }
 
     public function testBindingsExampleWithPipedInputEndsWithSpecialBindingsReplacedBecauseInputEnds()
     {
         $output = $this->execExample('echo hello | php 04-bindings.php');
 
-        $this->assertContains('you just said: hellö (6)' . PHP_EOL, $output);
+        $this->assertContainsString('you just said: hellö (6)' . PHP_EOL, $output);
     }
 
     public function testStubShowStdinIsReadableByDefault()
     {
         $output = $this->execExample('php ../tests/stub/01-check-stdin.php');
 
-        $this->assertContains('YES', $output);
+        $this->assertContainsString('YES', $output);
     }
 
     public function testStubCanCloseStdinAndIsNotReadable()
     {
         $output = $this->execExample('php ../tests/stub/02-close-stdin.php');
 
-        $this->assertContains('NO', $output);
+        $this->assertContainsString('NO', $output);
     }
 
     public function testStubCanCloseStdoutAndIsNotWritable()
@@ -113,7 +113,7 @@ class FunctionalExampleTest extends TestCase
 
         // starts with either "Interactive mode enabled" or "Interactive shell"
         $this->assertStringStartsWith('Interactive ', $output);
-        $this->assertNotContains('you just said:', $output);
+        $this->assertNotContainsString('you just said:', $output);
     }
 
     private function execExample($command)

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -12,7 +12,10 @@ class ReadlineTest extends TestCase
     private $output;
     private $readline;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpReadline()
     {
         $this->input = new ThroughStream();
         $this->output = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
@@ -621,11 +624,9 @@ class ReadlineTest extends TestCase
         $this->assertSame($this->readline, $this->readline->setAutocomplete(function () { }));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testAutocompleteThrowsIfNotCallable()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->assertSame($this->readline, $this->readline->setAutocomplete(123));
     }
 
@@ -931,7 +932,7 @@ class ReadlineTest extends TestCase
 
         $this->readline->onKeyTab();
 
-        $this->assertContains("\na  b\n", $buffer);
+        $this->assertContainsString("\na  b\n", $buffer);
     }
 
     public function testAutocompleteShowsAvailableOptionsWhenMultipleMatchWithEmptyWord()
@@ -945,7 +946,7 @@ class ReadlineTest extends TestCase
 
         $this->readline->onKeyTab();
 
-        $this->assertContains("\n  a\n", $buffer);
+        $this->assertContainsString("\n  a\n", $buffer);
     }
 
     public function testAutocompleteShowsAvailableOptionsWhenMultipleMatchIncompleteWord()
@@ -961,7 +962,7 @@ class ReadlineTest extends TestCase
 
         $this->readline->onKeyTab();
 
-        $this->assertContains("\nhello  hellu\n", $buffer);
+        $this->assertContainsString("\nhello  hellu\n", $buffer);
     }
 
     public function testAutocompleteShowsAvailableOptionsWhenMultipleMatchIncompleteWordWithUmlauts()
@@ -977,7 +978,7 @@ class ReadlineTest extends TestCase
 
         $this->readline->onKeyTab();
 
-        $this->assertContains("\nhällö  hällü\n", $buffer);
+        $this->assertContainsString("\nhällö  hällü\n", $buffer);
     }
 
     public function testAutocompleteShowsAvailableOptionsWithoutDuplicatesWhenMultipleMatch()
@@ -991,7 +992,7 @@ class ReadlineTest extends TestCase
 
         $this->readline->onKeyTab();
 
-        $this->assertContains("\na  b\n", $buffer);
+        $this->assertContainsString("\na  b\n", $buffer);
     }
 
     public function testAutocompleteShowsLimitedNumberOfAvailableOptionsWhenMultipleMatch()
@@ -1005,7 +1006,7 @@ class ReadlineTest extends TestCase
 
         $this->readline->onKeyTab();
 
-        $this->assertContains("\na  b  c  d  e  f  g  (+19 others)\n", $buffer);
+        $this->assertContainsString("\na  b  c  d  e  f  g  (+19 others)\n", $buffer);
     }
 
     public function testBindCustomFunctionFromBase()

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -11,7 +11,10 @@ class StdioTest extends TestCase
 {
     private $loop;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpLoop()
     {
         $this->loop = Factory::create();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,7 +46,13 @@ class TestCase extends BaseTestCase
      */
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
     protected function expectPromiseResolve($promise)
@@ -65,5 +71,44 @@ class TestCase extends BaseTestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         return $promise;
+    }
+
+    public function assertContainsString($needle, $haystack)
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            // PHPUnit 7.5+
+            $this->assertStringContainsString($needle, $haystack);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertContains($needle, $haystack);
+        }
+    }
+
+    public function assertNotContainsString($needle, $haystack)
+    {
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            // PHPUnit 7.5+
+            $this->assertStringNotContainsString($needle, $haystack);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertNotContains($needle, $haystack);
+        }
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.3.11 by Sebastian Bergmann and contributors.

...............................................................  63 / 193 ( 32%)
............................................................... 126 / 193 ( 65%)
............................................................... 189 / 193 ( 97%)
....                                                            193 / 193 (100%)

Time: 00:00.523, Memory: 10.00 MB

OK (193 tests, 319 assertions)
```