### PR TITLE
Refactor executing functional tests without ext-readline

### DIFF
--- a/tests/FunctionalExampleTest.php
+++ b/tests/FunctionalExampleTest.php
@@ -96,9 +96,9 @@ class FunctionalExampleTest extends TestCase
         $this->assertEquals('', $output);
     }
 
-    public function testStubCanEndWithoutExtensions()
+    public function testStubCanEndWithoutReadlineFunctions()
     {
-        $output = $this->execExample('php -n ../tests/stub/04-end.php');
+        $output = $this->execExample('php -d disable_functions=readline_callback_handler_install,readline_callback_handler_remove ../tests/stub/04-end.php');
 
         $this->assertEquals('', $output);
     }


### PR DESCRIPTION
Instead of executing without *any* extensions, we explicitly execute
without just the readline functions. This is necessary because Composer
2 now complains when its required extensions are not available.