### PR TITLE
Full support for PHP 8.1: Update preg_split() default $limit argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,8 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheResult="false">
+         cacheResult="false"
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Stdio React Test Suite">
             <directory>./tests/</directory>

--- a/src/Readline.php
+++ b/src/Readline.php
@@ -938,7 +938,7 @@ class Readline extends EventEmitter implements ReadableStreamInterface
      */
     private function strsplit($str)
     {
-        return preg_split('//u', $str, null, PREG_SPLIT_NO_EMPTY);
+        return preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
     }
 
     /**


### PR DESCRIPTION
This pull request addresses a deprecation concerning the `$limit` argument passed to `preg_split()`:

```
Deprecated: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in ./stdio-react/src/Readline.php on line 941
```
The adjustment should be compatible with the entire PHP version range supported by this library (>= 5.3).