### PR TITLE
Run tests on PHP 8.5 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -26,7 +27,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -45,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
       - name: Run hhvm composer.phar install
         uses: docker://hhvm/hhvm:3.30-lts-latest

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3",
         "clue/term-react": "^1.0 || ^0.1.1",
         "clue/utf8-react": "^1.0 || ^0.1",
-        "react/event-loop": "^1.2",
+        "react/event-loop": "^1.6",
         "react/stream": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
This changeset updates the test environment to run the test suite on PHP 8.5.

Builds on top of #111, #109, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297