### PR TITLE
Improve test suite to skip flaky closed stream tests

### DIFF
--- a/tests/FunctionalExampleTest.php
+++ b/tests/FunctionalExampleTest.php
@@ -110,7 +110,7 @@ class FunctionalExampleTest extends TestCase
 
     public function testStubCanEndWithoutOutput()
     {
-        $output = $this->execExample('php ../tests/stub/04-end.php');
+        $output = $this->execExample('php ../tests/stub/04-end.php < /dev/null');
 
         $this->assertEquals('', $output);
     }

--- a/tests/FunctionalExampleTest.php
+++ b/tests/FunctionalExampleTest.php
@@ -32,40 +32,50 @@ class FunctionalExampleTest extends TestCase
         $this->assertNotContainsString('you just said:', $output);
     }
 
-    public function testPeriodicExampleWithClosedInputQuitsImmediately()
+    public function testStubReportsStdinIsReadableByDefault()
     {
-        if (getenv('CI') === 'true' && (defined('HHVM_VERSION') || PHP_VERSION_ID >= 70000)) {
-            $this->markTestSkipped('Test fails for Github CI with PHP >= 7.0 and HHVM');
-        }
+        $output = $this->execExample('php ../tests/stub/01-check-stdin.php');
 
+        $this->assertContainsString('YES', $output);
+    }
+
+    public function testStubReportsStdinIsNotReadableWithoutDescriptor()
+    {
         if (PHP_VERSION_ID === 80108 || PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
             $this->markTestSkipped('Skip bugged PHP version: https://github.com/php/php-src/issues/8827');
         }
 
-        $output = $this->execExample('php 01-periodic.php <&-');
+        $output = $this->execExample('php ../tests/stub/01-check-stdin.php <&-');
 
-        if (strpos($output, 'said') !== false) {
-            $this->markTestIncomplete('Your platform exhibits a closed STDIN bug, this may need some further debugging');
+        // Closing STDIN frees file descriptor 0, which may then be reused by an
+        // internal stream descriptor so STDIN no longer refers to the console and
+        // is wrongly reported as readable. This is platform- and PHP-version
+        // dependent (see https://github.com/php/php-src/issues/8827). Skip here
+        // (and the dependent tests via @depends) when this platform does not
+        // report the closed STDIN as unreadable.
+        if (strpos($output, 'NO') === false) {
+            $this->markTestSkipped('Closed STDIN is not reliably detectable on this platform (file descriptor 0 reused)');
         }
+
+        $this->assertContainsString('NO', $output);
+    }
+
+    /**
+     * @depends testStubReportsStdinIsNotReadableWithoutDescriptor
+     */
+    public function testPeriodicExampleWithClosedInputQuitsImmediately()
+    {
+        $output = $this->execExample('php 01-periodic.php <&-');
 
         $this->assertNotContainsString('you just said:', $output);
     }
 
+    /**
+     * @depends testPeriodicExampleWithClosedInputQuitsImmediately
+     */
     public function testPeriodicExampleWithClosedInputAndOutputQuitsImmediatelyWithoutOutput()
     {
-        if (getenv('CI') === 'true' && (defined('HHVM_VERSION') || PHP_VERSION_ID >= 70000)) {
-            $this->markTestSkipped('Test fails for Github CI with PHP >= 7.0 and HHVM');
-        }
-
-        if (PHP_VERSION_ID === 80108 || PHP_VERSION_ID === 80107 || PHP_VERSION_ID === 80020) {
-            $this->markTestSkipped('Skip bugged PHP version: https://github.com/php/php-src/issues/8827');
-        }
-
         $output = $this->execExample('php 01-periodic.php <&- >&- 2>&-');
-
-        if (strpos($output, 'said') !== false) {
-            $this->markTestIncomplete('Your platform exhibits a closed STDIN bug, this may need some further debugging');
-        }
 
         $this->assertEquals('', $output);
     }
@@ -82,13 +92,6 @@ class FunctionalExampleTest extends TestCase
         $output = $this->execExample('echo hello | php 04-bindings.php');
 
         $this->assertContainsString('you just said: hellö (6)' . PHP_EOL, $output);
-    }
-
-    public function testStubShowStdinIsReadableByDefault()
-    {
-        $output = $this->execExample('php ../tests/stub/01-check-stdin.php');
-
-        $this->assertContainsString('YES', $output);
     }
 
     public function testStubCanCloseStdinAndIsNotReadable()


### PR DESCRIPTION
This changeset improves the test suite to skip the flaky closed stream tests and to avoid leaking terminal output when run on an interactive terminal.

Closing STDIN like this relies on undefined behavior that happens to work on some PHP versions and extensions but not others, so these tests now skip cleanly where it is not supported instead of failing or exhausting memory.

Builds on top of #57 and #78